### PR TITLE
Openning AppStore instead of iTunes Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ openApp("com.facebook.katana");
 
 ### iOS
 To open an app on iOS you need a schema registered by the app.
-Additionally you are required to whitelist the schemas for all apps you want to be able to open. Add them to your `app/App_Resources/iOS/Info.plist` (and additionally include "itms" schema used by the App Store):
+Additionally you are required to whitelist the schemas for all apps you want to be able to open. Add them to your `app/App_Resources/iOS/Info.plist` (and additionally include "itms-apps" schema used by the App Store):
 
 ```
   <key>LSApplicationQueriesSchemes</key>
   <array>
-    <string>itms</string>
+    <string>itms-apps</string>
     <string>twitter</string>
   </array>
 ```

--- a/open-app.ios.js
+++ b/open-app.ios.js
@@ -12,7 +12,7 @@ function openApp(appID, storeFallback, appleStoreId) {
     }
     else if (storeFallback && appleStoreId) {
         // can't open app - open store
-        url = NSURL.URLWithString("itms://itunes.apple.com/app/id" + appleStoreId);
+        url = NSURL.URLWithString("itms-apps://itunes.apple.com/app/id" + appleStoreId);
         if (sharedApplication.canOpenURL(url)) {
             sharedApplication.openURL(url);
         }


### PR DESCRIPTION
It will be better if the application is being opened directly in the AppStore instead of iTunes store. To do so I'm using itms-apps instead of itms.