### PR TITLE
Update open-app.ios.js

### DIFF
--- a/open-app.ios.js
+++ b/open-app.ios.js
@@ -3,7 +3,7 @@ var utils = require("utils/utils");
 
 function openApp(appID, storeFallback, appleStoreId) {
     if (storeFallback === void 0) { storeFallback = true; }
-    var sharedApplication = utils.ios.getter(UIApplication, UIApplication.sharedApplication);
+    var sharedApplication = UIApplication.sharedApplication;
     var url = NSURL.URLWithString(appID.trim());
     if (sharedApplication.canOpenURL(url)) {
         // open app


### PR DESCRIPTION
utils.ios.getter() is deprecated; use the respective native property instead

See https://stackoverflow.com/questions/56918708/error-ts2339-property-getter-does-not-exist-on-type-typeof-ios-in-nativesc